### PR TITLE
Fix session search for Accuracy Test data

### DIFF
--- a/js/FileLoader.js
+++ b/js/FileLoader.js
@@ -305,6 +305,10 @@ define(
 				var controllerId  = (record.length == LineLengths.AXF_XT) ? parseNumber(record[IDX.CONTROLLER]) : NaN;
 				var primaryCellId = (record.length == LineLengths.AXF_XT) ? parseNumber(record[IDX.CELL_ID]) : NaN;
 
+				var sessionProperties = {
+					sessionId: sessionId
+				};
+
 				var props = {
 					msgId: parseNumber(record[IDX.MSGID]),
 					sessionId: sessionId, // intentionally as String, as it gets very long
@@ -318,7 +322,7 @@ define(
 					primaryCellId: primaryCellId
 				};
 
-				var session = getSession(sessionId);
+				var session = getSession(sessionId, sessionProperties);
 				session.results.add(new AxfResult(props), OPT_SILENT);
 				stats.numResults++;
 			}

--- a/js/collections/sessions.js
+++ b/js/collections/sessions.js
@@ -8,6 +8,23 @@ define(
 			model: Session,
 
 			/**
+			 * Returns the session with the given ID.
+			 * @param  {Number} sessionId
+			 * @return {Session}
+			 */
+			findSession: function(sessionId) {
+
+				// try to find by "id" (for AXF sessions)
+				var session = this.get(sessionId);
+				if (!session) {
+					// look in the model attributes (for accuracy sessions, where "id" is mangled with fileId)
+					var properties = { sessionId: sessionId };
+					session = this.findWhere(properties);
+				}
+				return session;
+			},
+
+			/**
 			 * Returns the first session whose result list has a match for all the properties.
 			 * @param  {Object} resultProps List of key-value pairs that should match
 			 * @return {Session}
@@ -25,12 +42,12 @@ define(
 
 			/**
 			 * Returns the result with the given ID.
-			 * @param  {Number} id
+			 * @param  {Number} messageId
 			 * @return {BaseResult}
 			 */
-			findResult: function(id) {
+			findResult: function(messageId) {
 
-				var resultProps = { msgId: id };
+				var resultProps = { msgId: messageId };
 				// lookup session including the result
 				var session = this.findSessionWithResult(resultProps);
 

--- a/js/views/appview.js
+++ b/js/views/appview.js
@@ -404,7 +404,7 @@ define(
 				switch (query.topic) {
 					case SearchQuery.TOPIC_SESSION:
 						// TODO: fix this for new sessions-by-fileId world
-						var session = this.sessions.get(query.searchterm);
+						var session = this.sessions.findSession(query.searchterm);
 						if (session) {
 							this.sessionSelected(session);
 							this.sessionFocussed(session);


### PR DESCRIPTION
- since 8159e12 the "id" of Session models is mangled with the fileId
- introduced SessionList.findSession() to find sessions by the
  "sessionId" attribute of the model
